### PR TITLE
Implement skeleton SMTP server and parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Build directories
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Attacha
+# InboxProxy
+
+This project aims to build an email ingestion service.
+
+Phase 1 provides a simple SMTP listener and parser skeleton.

--- a/config.go
+++ b/config.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+    "log"
+    "os"
+    "strconv"
+)
+
+type Config struct {
+    ListenAddr      string
+    MaxMessageBytes int
+    StorageDir      string
+}
+
+func LoadConfig() Config {
+    cfg := Config{
+        ListenAddr:      getEnv("SMTP_ADDR", ":2525"),
+        MaxMessageBytes: getEnvInt("MAX_MESSAGE_BYTES", 10<<20),
+        StorageDir:      getEnv("STORAGE_DIR", "./data"),
+    }
+    if err := os.MkdirAll(cfg.StorageDir, 0o755); err != nil {
+        log.Fatalf("unable to create storage dir: %v", err)
+    }
+    return cfg
+}
+
+func getEnv(key, def string) string {
+    v := os.Getenv(key)
+    if v == "" {
+        return def
+    }
+    return v
+}
+
+func getEnvInt(key string, def int) int {
+    v := os.Getenv(key)
+    if v == "" {
+        return def
+    }
+    i, err := strconv.Atoi(v)
+    if err != nil {
+        log.Printf("invalid int for %s: %v", key, err)
+        return def
+    }
+    return i
+}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,14 @@
 package main
 
+import (
+    "log"
+)
+
 func main() {
-fmt.Println("Hi");
+    cfg := LoadConfig()
+    server := NewSMTPServer(cfg)
+    log.Printf("listening on %s", cfg.ListenAddr)
+    if err := server.ListenAndServe(); err != nil {
+        log.Fatalf("server failed: %v", err)
+    }
 }

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+    "bytes"
+    "io"
+
+    mailmsg "github.com/emersion/go-message/mail"
+)
+
+// Email represents a parsed email message.
+type Email struct {
+    From        string
+    To          []string
+    Subject     string
+    Text        string
+    HTML        string
+    Attachments []Attachment
+    Raw         []byte
+}
+
+// Attachment metadata
+type Attachment struct {
+    Filename    string
+    ContentType string
+    Size        int64
+    Path        string
+}
+
+// ParseEmail reads the raw message bytes and extracts common fields.
+func ParseEmail(raw []byte, cfg Config) (*Email, error) {
+    var email Email
+    email.Raw = raw
+
+    mr, err := mailmsg.NewReader(bytes.NewReader(raw))
+    if err != nil {
+        return nil, err
+    }
+    hdr := mr.Header
+    if from, err := hdr.AddressList("From"); err == nil && len(from) > 0 {
+        email.From = from[0].String()
+    }
+    if to, err := hdr.AddressList("To"); err == nil {
+        for _, a := range to {
+            email.To = append(email.To, a.String())
+        }
+    }
+    if subj, err := hdr.Subject(); err == nil {
+        email.Subject = subj
+    }
+
+    for {
+        p, err := mr.NextPart()
+        if err == io.EOF {
+            break
+        }
+        if err != nil {
+            return nil, err
+        }
+        switch h := p.Header.(type) {
+        case *mailmsg.InlineHeader:
+            ct, _, _ := h.ContentType()
+            b, _ := io.ReadAll(p.Body)
+            if ct == "text/plain" {
+                email.Text = string(b)
+            } else if ct == "text/html" {
+                email.HTML = string(b)
+            }
+        case *mailmsg.AttachmentHeader:
+            ct, _, _ := h.ContentType()
+            filename, _ := h.Filename()
+            path, err := StoreAttachment(cfg, filename, p.Body)
+            if err != nil {
+                return nil, err
+            }
+            size := int64(-1)
+            if lr, ok := p.Body.(interface{ Len() int }); ok {
+                size = int64(lr.Len())
+            }
+            email.Attachments = append(email.Attachments, Attachment{
+                Filename:    filename,
+                ContentType: ct,
+                Size:        size,
+                Path:        path,
+            })
+        }
+    }
+
+    return &email, nil
+}

--- a/server.go
+++ b/server.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+    "io"
+    "log"
+
+    smtp "github.com/emersion/go-smtp"
+)
+
+type Backend struct{}
+
+func (b *Backend) Login(state *smtp.ConnectionState, username, password string) (smtp.Session, error) {
+    return nil, smtp.ErrAuthUnsupported
+}
+
+func (b *Backend) AnonymousLogin(state *smtp.ConnectionState) (smtp.Session, error) {
+    return &Session{}, nil
+}
+
+type Session struct {
+    from string
+    to   []string
+}
+
+func (s *Session) Mail(from string, opts smtp.MailOptions) error {
+    s.from = from
+    return nil
+}
+
+func (s *Session) Rcpt(to string) error {
+    s.to = append(s.to, to)
+    return nil
+}
+
+func (s *Session) Data(r io.Reader) error {
+    raw, err := io.ReadAll(r)
+    if err != nil {
+        return err
+    }
+    cfg := LoadConfig()
+    email, err := ParseEmail(raw, cfg)
+    if err != nil {
+        return err
+    }
+    log.Printf("received mail from %s to %v subject=%s", email.From, email.To, email.Subject)
+    return nil
+}
+
+func (s *Session) Reset() {}
+
+func (s *Session) Logout() error { return nil }
+
+func NewSMTPServer(cfg Config) *smtp.Server {
+    backend := &Backend{}
+    s := smtp.NewServer(backend)
+    s.Addr = cfg.ListenAddr
+    s.Domain = "localhost"
+    s.MaxMessageBytes = cfg.MaxMessageBytes
+    s.AllowInsecureAuth = true
+    return s
+}

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+    "fmt"
+    "io"
+    "os"
+    "path/filepath"
+)
+
+// StoreAttachment saves the attachment reader to disk and returns the path
+func StoreAttachment(cfg Config, filename string, r io.Reader) (string, error) {
+    path := filepath.Join(cfg.StorageDir, filename)
+    f, err := os.Create(path)
+    if err != nil {
+        return "", fmt.Errorf("create file: %w", err)
+    }
+    defer f.Close()
+    if _, err := io.Copy(f, r); err != nil {
+        return "", fmt.Errorf("write file: %w", err)
+    }
+    return path, nil
+}
+
+// TODO: Implement more robust storage (e.g., S3)


### PR DESCRIPTION
## Summary
- add configuration loader with env vars
- implement SMTP server skeleton
- parse email headers, bodies, and attachments
- save attachments to disk
- update README

## Testing
- `go mod tidy` *(fails: no route to host)*
- `go build ./...` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683c597a74f4833384d771c234579c2a