### PR TITLE
Add delivery notification dispatcher and retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# Attacha
+# InboxProxy
+
+This repository contains simple examples related to file delivery
+notifications. It demonstrates how to dispatch notifications and retry
+failed deliveries.
+
+## Notification System
+
+Notifications are sent using a `Notifier` interface. The repository
+includes a `LoggerNotifier` that writes messages to the standard log.
+
+A `Dispatcher` coordinates sending messages and sets a status flag based
+on whether the notification succeeds.
+
+Statuses include:
+
+- `StatusPending` – the message is waiting to be delivered.
+- `StatusComplete` – the notification succeeded.
+- `StatusFailed` – retries have been exhausted and the message failed.
+
+The dispatcher retries a notification up to a configurable number of
+attempts with a delay between tries.
+
+## Example
+
+```
+go run ./
+```
+
+The example sends a single message using the logger notifier. You can
+adapt the `Notifier` interface to integrate with email, webhooks or
+Slack.

--- a/main.go
+++ b/main.go
@@ -1,5 +1,24 @@
 package main
 
+import (
+	"context"
+	"time"
+
+	"github.com/demarijm/inboxproxy/notification"
+)
+
 func main() {
-fmt.Println("Hi");
+	dispatcher := notification.Dispatcher{
+		Notifier:   notification.LoggerNotifier{},
+		MaxRetries: 3,
+		RetryDelay: time.Second,
+	}
+
+	msg := &notification.Message{
+		ID:        "1",
+		Recipient: "user@example.com",
+		Body:      "File is ready",
+	}
+
+	dispatcher.Dispatch(context.Background(), msg)
 }

--- a/notification/dispatcher.go
+++ b/notification/dispatcher.go
@@ -1,0 +1,35 @@
+package notification
+
+import (
+	"context"
+	"time"
+)
+
+// Dispatcher handles sending messages with retry logic.
+type Dispatcher struct {
+	Notifier   Notifier
+	MaxRetries int
+	RetryDelay time.Duration
+}
+
+// Dispatch attempts to send the message using the configured notifier.
+func (d *Dispatcher) Dispatch(ctx context.Context, msg *Message) {
+	msg.Status = StatusPending
+	for attempt := 0; attempt <= d.MaxRetries; attempt++ {
+		err := d.Notifier.Send(ctx, msg)
+		if err == nil {
+			msg.Status = StatusComplete
+			return
+		}
+		msg.Retries++
+		if attempt < d.MaxRetries {
+			select {
+			case <-ctx.Done():
+				msg.Status = StatusFailed
+				return
+			case <-time.After(d.RetryDelay):
+			}
+		}
+	}
+	msg.Status = StatusFailed
+}

--- a/notification/logger_notifier.go
+++ b/notification/logger_notifier.go
@@ -1,0 +1,18 @@
+package notification
+
+import (
+	"context"
+	"log"
+)
+
+// LoggerNotifier writes notifications to the standard logger.
+type LoggerNotifier struct{}
+
+// Name returns the notifier name.
+func (LoggerNotifier) Name() string { return "logger" }
+
+// Send logs the message body and recipient.
+func (LoggerNotifier) Send(ctx context.Context, msg *Message) error {
+	log.Printf("sending to %s: %s", msg.Recipient, msg.Body)
+	return nil
+}

--- a/notification/message.go
+++ b/notification/message.go
@@ -1,0 +1,22 @@
+package notification
+
+// Status represents the current state of a notification message.
+type Status int
+
+const (
+	// StatusPending indicates the message is queued for delivery.
+	StatusPending Status = iota
+	// StatusComplete indicates the message was delivered successfully.
+	StatusComplete
+	// StatusFailed indicates delivery ultimately failed.
+	StatusFailed
+)
+
+// Message represents a single notification payload.
+type Message struct {
+	ID        string
+	Recipient string
+	Body      string
+	Status    Status
+	Retries   int
+}

--- a/notification/notifier.go
+++ b/notification/notifier.go
@@ -1,0 +1,9 @@
+package notification
+
+import "context"
+
+// Notifier defines how to send a message to a recipient.
+type Notifier interface {
+	Send(ctx context.Context, msg *Message) error
+	Name() string
+}


### PR DESCRIPTION
## Summary
- implement notification framework with status flags
- add a dispatcher with retry logic
- provide a logger-based notifier example
- update main example
- document notification system in README

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683c5a20977c8333bc791698f568e22c