### PR TITLE
Implement hook execution engine

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "sample",
+    "sender": "alice@example.com",
+    "subject_contains": "Test",
+    "action": {
+      "type": "command",
+      "command": "echo triggered"
+    }
+  }
+]

--- a/hooks/hook.go
+++ b/hooks/hook.go
@@ -1,0 +1,42 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Action describes what to do when a hook matches.
+type Action struct {
+	Type    string `json:"type"` // "http_post" or "command"
+	URL     string `json:"url,omitempty"`
+	Command string `json:"command,omitempty"`
+}
+
+// Hook defines matching rules and the action to execute.
+type Hook struct {
+	ID              string `json:"id"`
+	Sender          string `json:"sender,omitempty"`
+	SubjectContains string `json:"subject_contains,omitempty"`
+	FileType        string `json:"file_type,omitempty"`
+	Action          Action `json:"action"`
+}
+
+// EmailEvent represents minimal information about an email.
+type EmailEvent struct {
+	Sender   string
+	Subject  string
+	FileType string
+}
+
+// LoadHooks reads hook definitions from a JSON file.
+func LoadHooks(path string) ([]Hook, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var hooks []Hook
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		return nil, err
+	}
+	return hooks, nil
+}

--- a/hooks/runner.go
+++ b/hooks/runner.go
@@ -1,0 +1,99 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// HookRunner executes hooks in response to email events.
+type HookRunner struct {
+	hooks  []Hook
+	events chan EmailEvent
+	wg     sync.WaitGroup
+}
+
+// NewHookRunner creates a runner with the given hooks.
+func NewHookRunner(hooks []Hook) *HookRunner {
+	return &HookRunner{
+		hooks:  hooks,
+		events: make(chan EmailEvent, 10),
+	}
+}
+
+// Start begins the event processing goroutine.
+func (hr *HookRunner) Start() {
+	hr.wg.Add(1)
+	go hr.loop()
+}
+
+// Stop stops the runner and waits for completion.
+func (hr *HookRunner) Stop() {
+	close(hr.events)
+	hr.wg.Wait()
+}
+
+// Process submits an email event for processing.
+func (hr *HookRunner) Process(ev EmailEvent) {
+	hr.events <- ev
+}
+
+// AddHook registers a new hook at runtime.
+func (hr *HookRunner) AddHook(h Hook) {
+	hr.hooks = append(hr.hooks, h)
+}
+
+func (hr *HookRunner) loop() {
+	defer hr.wg.Done()
+	for ev := range hr.events {
+		for _, h := range hr.hooks {
+			if !hr.match(h, ev) {
+				continue
+			}
+			if err := hr.execute(h, ev); err != nil {
+				log.Printf("hook %s failed: %v", h.ID, err)
+			} else {
+				log.Printf("hook %s executed successfully", h.ID)
+			}
+		}
+	}
+}
+
+func (hr *HookRunner) match(h Hook, ev EmailEvent) bool {
+	if h.Sender != "" && h.Sender != ev.Sender {
+		return false
+	}
+	if h.SubjectContains != "" && !strings.Contains(ev.Subject, h.SubjectContains) {
+		return false
+	}
+	if h.FileType != "" && h.FileType != ev.FileType {
+		return false
+	}
+	return true
+}
+
+func (hr *HookRunner) execute(h Hook, ev EmailEvent) error {
+	switch h.Action.Type {
+	case "command":
+		cmd := exec.Command("sh", "-c", h.Action.Command)
+		return cmd.Run()
+	case "http_post":
+		payload, _ := json.Marshal(ev)
+		resp, err := http.Post(h.Action.URL, "application/json", bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("http %d", resp.StatusCode)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown action type %s", h.Action.Type)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,30 @@
 package main
 
+import (
+	"flag"
+	"log"
+
+	"github.com/demarijm/inboxproxy/hooks"
+)
+
 func main() {
-fmt.Println("Hi");
+	sender := flag.String("sender", "", "email sender")
+	subject := flag.String("subject", "", "email subject")
+	fileType := flag.String("file", "", "file type")
+	config := flag.String("config", "hooks.json", "path to hooks json")
+	flag.Parse()
+
+	hs, err := hooks.LoadHooks(*config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	runner := hooks.NewHookRunner(hs)
+	runner.Start()
+	runner.Process(hooks.EmailEvent{
+		Sender:   *sender,
+		Subject:  *subject,
+		FileType: *fileType,
+	})
+	runner.Stop()
 }


### PR DESCRIPTION
## Summary
- add hook structs and config loader
- add asynchronous hook runner with command and HTTP actions
- update `main.go` to drive hooks
- include example `hooks.json` config

## Testing
- `go vet ./...`
- `go test ./... -run TestNonexistent`

------
https://chatgpt.com/codex/tasks/task_e_683c59c2220883339b46e1abcb5ecb9b